### PR TITLE
Fix missing external modules with .d.ts extension

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -255,7 +255,13 @@ function increaseProjectForReferenceAndImports(files: string[]) {
                     .concat(
                     preProcessedFileInfo.importedFiles
                         .filter((fileReference) => pathIsRelative(fileReference.filename))
-                        .map(fileReference => path.resolve(dir, fileReference.filename + '.ts'))
+                        .map(fileReference => {
+                            var file = path.resolve(dir, fileReference.filename + '.ts');
+                            if (!fs.existsSync(file)) {
+                                file = path.resolve(dir, fileReference.filename + '.d.ts');
+                            }
+                            return file;
+                        })
                     )
                 );
         });


### PR DESCRIPTION
The TypeScript compiler will look for files with both `.ts` and `.d.ts` extensions when resolving external imports, so atom-typescript also needs to do this.